### PR TITLE
<colgroup>标签缺少<col span="10">

### DIFF
--- a/html/tables/assessment-finished/planets-data.html
+++ b/html/tables/assessment-finished/planets-data.html
@@ -13,6 +13,7 @@
       <colgroup>
         <col span="2">
         <col style="border: 2px solid black">
+        <col span="10">
       </colgroup>
       <thead>
         <tr>


### PR DESCRIPTION

[Html Checker]中报错
  `Error:A table row was 13 columns wide and exceeded the column count established using column markup (6).` 
对照英文版缺少了`<col span="">`
>       <colgroup>
>         <col span="2">
>         <col style="border: 2px solid black">
>         <col span="9">
>       </colgroup>